### PR TITLE
Add support for ingoring new relic transction when execption occurs

### DIFF
--- a/src/new_reliquary/core.clj
+++ b/src/new_reliquary/core.clj
@@ -26,19 +26,15 @@
 
 (defn with-newrelic-transaction
   ([category transaction-name custom-parameters callback]
-    (.callWithTrace tracer category transaction-name custom-parameters callback))
+    (try
+      (.callWithTrace tracer category transaction-name custom-parameters callback)
+      (catch Throwable e
+        (ignore-transaction)
+        (throw e))))
+
   ([category transaction-name callback]
     (with-newrelic-transaction category transaction-name {} callback)))
 
-(defn with-successfully-newrelic-transaction
-  ([category transaction-name callback]
-    (with-successfully-newrelic-transaction category transaction-name {} callback))
-  ([category transaction-name custom-parameters callback]
-    (try
-        (with-newrelic-transaction category transaction-name custom-parameters callback)
-      (catch Throwable e
-        (ignore-transaction)
-        (throw e)))))
 
 (defn notice-error [error]
   (NewRelic/noticeError error))

--- a/src/new_reliquary/core.clj
+++ b/src/new_reliquary/core.clj
@@ -36,7 +36,7 @@
   ([category transaction-name custom-parameters callback]
     (try
         (with-newrelic-transaction category transaction-name custom-parameters callback)
-      (catch Exception e
+      (catch Throwable e
         (ignore-transaction)
         (throw e)))))
 

--- a/src/new_reliquary/core.clj
+++ b/src/new_reliquary/core.clj
@@ -10,6 +10,9 @@
 (defn add-custom-parameter [key val]
   (NewRelic/addCustomParameter key val))
 
+(defn ingore-transaction []
+  (NewRelic/ignoreTransaction))
+
 (deftype NewRelicTracer []
   NewRelicTraceable (^{Trace {:dispatcher true}}
                       callWithTrace [this category transaction-name query-params callback]
@@ -26,6 +29,16 @@
     (.callWithTrace tracer category transaction-name custom-parameters callback))
   ([category transaction-name callback]
     (with-newrelic-transaction category transaction-name {} callback)))
+
+(defn with-successfully-newrelic-transaction
+  ([category transaction-name callback]
+    (with-successfully-newrelic-transaction category transaction-name {} callback))
+  ([category transaction-name custom-parameters callback]
+    (try
+        (with-newrelic-transaction category transaction-name custom-parameters callback)
+      (catch Exception e
+        (ingore-transaction)
+        (throw e)))))
 
 (defn notice-error [error]
   (NewRelic/noticeError error))

--- a/src/new_reliquary/core.clj
+++ b/src/new_reliquary/core.clj
@@ -10,7 +10,7 @@
 (defn add-custom-parameter [key val]
   (NewRelic/addCustomParameter key val))
 
-(defn ingore-transaction []
+(defn ignore-transaction []
   (NewRelic/ignoreTransaction))
 
 (deftype NewRelicTracer []
@@ -37,7 +37,7 @@
     (try
         (with-newrelic-transaction category transaction-name custom-parameters callback)
       (catch Exception e
-        (ingore-transaction)
+        (ignore-transaction)
         (throw e)))))
 
 (defn notice-error [error]

--- a/test/new_reliquary/test.clj
+++ b/test/new_reliquary/test.clj
@@ -70,15 +70,7 @@
     (is (= @set-transaction-name-calls [[category "my transaction"]]))
     (is (= @add-custom-parameter-calls [["huge-clojure-fan" "true"]]))))
 
-(deftest with-successfully-newrelic-transaction-when-exception-occurs
+(deftest ignores-transaction-when-exception-occurs
   (testing "ignores transaction when exception occurs"
-    (is (thrown? Exception (core/with-successfully-newrelic-transaction category "my transaction" {:huge-clojure-fan true} #((throw (Exception. "Say Ni!"))))))
+    (is (thrown? Exception (core/with-newrelic-transaction category "my transaction" {:huge-clojure-fan true} #((throw (Exception. "Say Ni!"))))))
     (is (=@ignore-transaction-calls 1))))
-
-(deftest with-successfully-newrelic-transaction-without-excetion-occured
-  (testing "reports transaction when no exception occurred"
-    (core/with-successfully-newrelic-transaction category "my transaction" {:huge-clojure-fan true} #())
-    (is (= @set-transaction-name-calls [[category "my transaction"]]))
-    (is (= @add-custom-parameter-calls [["huge-clojure-fan" "true"]]))
-    (is (=@ignore-transaction-calls 0))))
-

--- a/test/new_reliquary/test.clj
+++ b/test/new_reliquary/test.clj
@@ -13,7 +13,7 @@
 
 (def set-transaction-name-calls (atom []))
 (def add-custom-parameter-calls (atom []))
-(def ingore-transaction-calls   (atom 0))
+(def ignore-transaction-calls   (atom 0))
 
 (defn final-handler [request] {:body request})
 (def app (wrap-params (wrap-newrelic-transaction final-handler category)))
@@ -21,10 +21,10 @@
 (use-fixtures :each (fn [test]
                       (with-redefs [new-reliquary.core/set-transaction-name (fn [category name] (swap! set-transaction-name-calls conj [category name]))
                                     new-reliquary.core/add-custom-parameter (fn [key val] (swap! add-custom-parameter-calls conj [key val]))
-                                    new-reliquary.core/ingore-transaction   (fn [] (swap! ingore-transaction-calls inc))]
+                                    new-reliquary.core/ignore-transaction   (fn [] (swap! ignore-transaction-calls inc))]
                         (reset! set-transaction-name-calls [])
                         (reset! add-custom-parameter-calls [])
-                        (reset! ingore-transaction-calls   0)
+                        (reset! ignore-transaction-calls   0)
                         (test))))
 
 (deftest with-request-params
@@ -73,11 +73,12 @@
 (deftest with-successfully-newrelic-transaction-when-exception-occurs
   (testing "ignores transaction when exception occurs"
     (is (thrown? Exception (core/with-successfully-newrelic-transaction category "my transaction" {:huge-clojure-fan true} #((throw (Exception. "Say Ni!"))))))
-    (is (=@ingore-transaction-calls 1))))
+    (is (=@ignore-transaction-calls 1))))
 
 (deftest with-successfully-newrelic-transaction-without-excetion-occured
   (testing "reports transaction when no exception occurred"
     (core/with-successfully-newrelic-transaction category "my transaction" {:huge-clojure-fan true} #())
     (is (= @set-transaction-name-calls [[category "my transaction"]]))
     (is (= @add-custom-parameter-calls [["huge-clojure-fan" "true"]]))
-    (is (=@ingore-transaction-calls 0))))
+    (is (=@ignore-transaction-calls 0))))
+

--- a/test/new_reliquary/test.clj
+++ b/test/new_reliquary/test.clj
@@ -13,15 +13,18 @@
 
 (def set-transaction-name-calls (atom []))
 (def add-custom-parameter-calls (atom []))
+(def ingore-transaction-calls   (atom 0))
 
 (defn final-handler [request] {:body request})
 (def app (wrap-params (wrap-newrelic-transaction final-handler category)))
 
 (use-fixtures :each (fn [test]
                       (with-redefs [new-reliquary.core/set-transaction-name (fn [category name] (swap! set-transaction-name-calls conj [category name]))
-                                    new-reliquary.core/add-custom-parameter (fn [key val] (swap! add-custom-parameter-calls conj [key val]))]
+                                    new-reliquary.core/add-custom-parameter (fn [key val] (swap! add-custom-parameter-calls conj [key val]))
+                                    new-reliquary.core/ingore-transaction   (fn [] (swap! ingore-transaction-calls inc))]
                         (reset! set-transaction-name-calls [])
                         (reset! add-custom-parameter-calls [])
+                        (reset! ingore-transaction-calls   0)
                         (test))))
 
 (deftest with-request-params
@@ -66,3 +69,15 @@
     (core/with-newrelic-transaction category "my transaction" {:huge-clojure-fan true} #())
     (is (= @set-transaction-name-calls [[category "my transaction"]]))
     (is (= @add-custom-parameter-calls [["huge-clojure-fan" "true"]]))))
+
+(deftest with-successfully-newrelic-transaction-when-exception-occurs
+  (testing "ignores transaction when exception occurs"
+    (is (thrown? Exception (core/with-successfully-newrelic-transaction category "my transaction" {:huge-clojure-fan true} #((throw (Exception. "Say Ni!"))))))
+    (is (=@ingore-transaction-calls 1))))
+
+(deftest with-successfully-newrelic-transaction-without-excetion-occured
+  (testing "reports transaction when no exception occurred"
+    (core/with-successfully-newrelic-transaction category "my transaction" {:huge-clojure-fan true} #())
+    (is (= @set-transaction-name-calls [[category "my transaction"]]))
+    (is (= @add-custom-parameter-calls [["huge-clojure-fan" "true"]]))
+    (is (=@ingore-transaction-calls 0))))


### PR DESCRIPTION
Goal is to ignore trace for action when exception is raised. New Relic documentation regarding cancelling transaction tracing https://docs.newrelic.com/docs/agents/java-agent/custom-instrumentation/java-agent-api#api_methods
