### PR TITLE
Update newrelic-api from 3.13.0 to 3.17.0 and pump version with patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Clojure wrapper for New Relic
 
 Add this to your Leiningen project.clj :dependencies:
 
-    [yleisradio/new-reliquary "0.1.4"]
+    [yleisradio/new-reliquary "0.1.5"]
 
 Jar is available in Clojars.
 

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject yleisradio/new-reliquary "0.1.4"
+(defproject yleisradio/new-reliquary "0.1.5"
   :description "Clojure newrelic java api wrapper"
   :url "https://github.com/Yleisradio/new-reliquary"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [com.newrelic.agent.java/newrelic-api "3.13.0"]]
+                 [com.newrelic.agent.java/newrelic-api "3.17.0"]]
   :profiles { :dev { :dependencies [[ring/ring-core "1.3.2"]
                                     [ring-mock "0.1.5"]
                                     [org.clojure/tools.trace "0.7.8"]]}}


### PR DESCRIPTION
- Update newrelic-api from 3.13.0 to 3.17.0
- Pump version with from 0.1.4 to 0.1.5
