### PR TITLE
Docs: run wrap-params before wrap-newrelic-transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,7 @@ This can be achieved easily by using ring.middleware.params/wrap-params.
                 [ring.middleware.params :refer [wrap-params]]))
 
     (defn final-handler [request] {:body "Hello world"})
-    (def app (wrap-params
-                (wrap-newrelic-transaction final-handler "my transaction category")))
+    (def app (wrap-newrelic-transaction (wrap-params final-handler) "my transaction category")))
 
 
 ## License


### PR DESCRIPTION
Shouldn't wrap-params wrap the handler _before_ wrap-newrelic-transaction?
