### PR TITLE
Use parametrized Compojure request URI if possible. & Add an option to add the HTTP method to the New Relic transaction name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,17 @@ transaction. See: http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/
 
 Middleware to start NewRelic web transaction. Located in `new-reliquary.ring`
 
+If you're using [Compojure](https://github.com/weavejester/compojure) 1.4.0 or later, 
+New Reliquary will use Compojure route URLs with placeholder parameters (i.e. 
+`/users:id` instead of `/users/5`) as New Relic transaction names.
+
 If you want to add query parameters as new relic custom params, make sure that 
 request contains hash map `:query-params` (not in the default ring setup).
 This can be achieved easily by using `ring.middleware.params/wrap-params`.
+
+New Reliquary can also automatically add the HTTP method to the transaction names.
+Use the optional `:add-method-to-transaction-name true` parameter when constructing
+the middleware to enable the feature.
 
 ### API
 
@@ -93,7 +101,7 @@ This can be achieved easily by using `ring.middleware.params/wrap-params`.
 
 (defn request-handler [request] {:body "Hello world"})
 (def app (-> request-handler
-            (wrap-newrelic-transaction)
+            (wrap-newrelic-transaction :add-method-to-transaction-name true)
             (wrap-params)))
 ```
 

--- a/src/new_reliquary/ring.clj
+++ b/src/new_reliquary/ring.clj
@@ -46,7 +46,8 @@
    505 "HTTP Version Not Supported"})
 
 (defn- resolve-uri [req]
-  (:uri req))
+  (or (get-in req [:compojure/route 1])
+      (:uri req)))
 
 (defn- resolve-query-params [req]
   (->> (:query-params req)

--- a/src/new_reliquary/ring.clj
+++ b/src/new_reliquary/ring.clj
@@ -1,5 +1,6 @@
 (ns new-reliquary.ring
-  (:require [new-reliquary.core :as newrelic])
+  (:require [new-reliquary.core :as newrelic]
+            [clojure.string :refer [upper-case]])
   (:import (com.newrelic.api.agent Response HeaderType Request)))
 
 ; see http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
@@ -45,9 +46,12 @@
    504 "Gateway Timeout"
    505 "HTTP Version Not Supported"})
 
-(defn- resolve-uri [req]
-  (or (get-in req [:compojure/route 1])
-      (:uri req)))
+(defn- resolve-uri [req add-method-to-transaction-name]
+  (let [uri (or (get-in req [:compojure/route 1])
+                (:uri req))]
+    (if add-method-to-transaction-name
+      (str "/" (-> (:request-method req) name upper-case) " " uri)
+      uri)))
 
 (defn- resolve-query-params [req]
   (->> (:query-params req)
@@ -66,8 +70,8 @@
        (first)
        (second)))
 
-(deftype NewRelicRingWrapperRequest [req] Request
-  (getRequestURI [_] (resolve-uri req))
+(deftype NewRelicRingWrapperRequest [req add-method-to-transaction-name] Request
+  (getRequestURI [_] (resolve-uri req add-method-to-transaction-name))
   (getRemoteUser [_] nil)
   (getParameterNames [_] (keys (resolve-query-params req)))
   (getParameterValues [_ name]
@@ -87,14 +91,15 @@
   (doseq [[key value] (sort-by key (seq params))]
     (newrelic/add-custom-parameter key value)))
 
-(defn- web-transaction [request-hander request]
+(defn- web-transaction [request-hander request add-method-to-transaction-name]
   (fn []
-    (let [newrelic-req (NewRelicRingWrapperRequest. request)
+    (let [newrelic-req (NewRelicRingWrapperRequest. request add-method-to-transaction-name)
           response     (request-hander request)
           newrelic-res (NewRelicRingWrapperResponse. response)]
       (add-query-params (resolve-query-params request))
       (newrelic/set-request-response newrelic-req newrelic-res)
       response)))
 
-(defn wrap-newrelic-transaction [handler]
-  (fn [request] (newrelic/with-newrelic-transaction (web-transaction handler request))))
+(defn wrap-newrelic-transaction [handler & {:keys [add-method-to-transaction-name]
+                                            :or {add-method-to-transaction-name false}}]
+  (fn [request] (newrelic/with-newrelic-transaction (web-transaction handler request add-method-to-transaction-name))))

--- a/test/new_reliquary/ring_test.clj
+++ b/test/new_reliquary/ring_test.clj
@@ -95,3 +95,15 @@
                                 (assoc :compojure/route [:any "/dogs/:id"]))]
       (app compojure-request)
       (is (= (get-newrelic-request-urls) ["/dogs/:id"])))))
+
+(deftest with-method-in-transaction-name
+  (let [app (-> (fn [_] {:body "OK"
+                         :headers {"Content-Type" "text/html"}
+                         :status 200})
+                (ring/wrap-newrelic-transaction :add-method-to-transaction-name true)
+                (wrap-params))]
+    (testing "adds the HTTP method to request URI"
+      (app (request :get "http://test.fi/dogs"))
+      (is (= (get-newrelic-request-urls) ["/GET /dogs"]))
+      (is (= (get-newrelic-response-statuses) [200]))
+      (is (= (get-newrelic-response-content-types) ["text/html"])))))

--- a/test/new_reliquary/ring_test.clj
+++ b/test/new_reliquary/ring_test.clj
@@ -88,3 +88,10 @@
       (app (request :get "http://test.fi/dogs"))
       (is (= (get-newrelic-response-content-types) ["text/xml"]))
       (is (= (get-newrelic-response-statuses) [404])))))
+
+(deftest with-compojure-route-information
+  (testing "picks the parametrized compojure url from route info if available"
+    (let [compojure-request (-> (request :get "http://test.fi/dogs/kultainen-noutaja")
+                                (assoc :compojure/route [:any "/dogs/:id"]))]
+      (app compojure-request)
+      (is (= (get-newrelic-request-urls) ["/dogs/:id"])))))


### PR DESCRIPTION
Not sure what the option name should be . `:add-method-to-transaction-name` might be a bit too long.
