### PR TITLE
Upgraded New Relic API dependency to version 4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Basic NewRelic transaction tracing utilities located in `new-reliquary.core`
 
 #### `with-newrelic-transaction`
 
-```clojure 
+```clojure
 (defn with-newrelic-transaction
   ([category transaction-name custom-params callback] ...)
   ([category transaction-name callback]               ...)
@@ -33,7 +33,7 @@ Basic NewRelic transaction tracing utilities located in `new-reliquary.core`
 ```
 
 Creates a transaction with optional transaction name and custom params.
-If transaction name is not passed, then `set-transaction-name` should 
+If transaction name is not passed, then `set-transaction-name` should
 be used inside the transaction.
 
 #### `set-transaction-name [category name]`
@@ -57,7 +57,7 @@ transaction. See: http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/
 
 ### Examples
 
-```clojure 
+```clojure
 (:require [new-reliquary.core :as newrelic])
 
 (defn update-facebook-likes [] ...)
@@ -67,8 +67,8 @@ transaction. See: http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/
     "Facebook data updating"
     {:user "jk" :huge-clojure-fan true}
     update-facebook-likes)
-    
-(newrelic/with-newrelic-transaction 
+
+(newrelic/with-newrelic-transaction
   (fn [] (newrelic/set-transaction-name "backend" "poller") ...)
 ```
 
@@ -77,7 +77,7 @@ transaction. See: http://newrelic.github.io/java-agent-api/javadoc/com/newrelic/
 
 Middleware to start NewRelic web transaction. Located in `new-reliquary.ring`
 
-If you want to add query parameters as new relic custom params, make sure that 
+If you want to add query parameters as new relic custom params, make sure that
 request contains hash map `:query-params` (not in the default ring setup).
 This can be achieved easily by using `ring.middleware.params/wrap-params`.
 

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject yleisradio/new-reliquary "1.0.1"
+(defproject yleisradio/new-reliquary "1.1.0"
   :description "Clojure newrelic java api wrapper"
   :url "https://github.com/Yleisradio/new-reliquary"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [com.newrelic.agent.java/newrelic-api "3.46.0"]]
+                 [com.newrelic.agent.java/newrelic-api "4.0.0"]]
   :profiles { :dev { :dependencies [[ring/ring-core "1.6.3"]
                                     [ring-mock "0.1.5"]
                                     [org.clojure/tools.trace "0.7.9"]]}}


### PR DESCRIPTION
This will be released as version 1.1.0.